### PR TITLE
Fix org-starter recipe again

### DIFF
--- a/recipes/org-starter
+++ b/recipes/org-starter
@@ -2,4 +2,5 @@
  :repo "akirak/org-starter"
  :fetcher github
  :files (:defaults
-         (:exclude "org-starter-swiper.el" "org-starter-extras.el")))
+         (:exclude "counsel-org-starter.el" "helm-org-starter.el"
+                   "org-starter-swiper.el" "org-starter-extras.el")))

--- a/recipes/org-starter
+++ b/recipes/org-starter
@@ -1,8 +1,5 @@
-(org-starter :repo "akirak/org-starter"
-             :fetcher github
-             :files
-             ("org-starter.el" "org-starter-*.el"
-              "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
-              (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el"
-                        "org-starter-swiper.el"
-                        "org-starter-extras.el")))
+(org-starter
+ :repo "akirak/org-starter"
+ :fetcher github
+ :files (:defaults
+         (:exclude "org-starter-swiper.el" "org-starter-extras.el")))


### PR DESCRIPTION
My work log and that log tell us those recipes produce same effect.

```
 ~/d/f/melpa    hub pr checkout 6266                              1387ms  金  7/ 5 09:27:16 2019
Switched to branch 'org-starter-update'


 ~/d/f/melpa   org-starter-update  make recipes/org-starter       3935ms  金  7/ 5 22:43:35 2019
 • Building package org-starter ...
Package: org-starter
Fetcher: github
Source:  https://github.com/akirak/org-starter.git

Updating /Users/conao/dev/forks/melpa/working/org-starter/
Built org-starter in 3.091s, finished at Fri Jul  5 22:43:42 2019
 ✓ Success:
128 -rw-r--r--  1 conao  staff    61K  7  5 22:43 packages/org-starter-20190703.2159.el
  8 -rw-r--r--  1 conao  staff   371B  7  5 22:43 packages/org-starter-20190703.2159.entry
160 -rw-r--r--  1 conao  staff    78K  7  5 03:26 packages/org-starter-20190703.2159.tar
  8 -rw-r--r--  1 conao  staff   969B  7  5 22:43 packages/org-starter-badge.svg
  8 -rw-r--r--  1 conao  staff    68B  7  5 22:43 packages/org-starter-readme.txt



 ~/d/f/melpa   org-starter-update  git diff                                金  7/ 5 22:44:50 2019
diff --git a/recipes/org-starter b/recipes/org-starter
index b43293a8..ff4f91e6 100644
--- a/recipes/org-starter
+++ b/recipes/org-starter
@@ -1,8 +1,5 @@
-(org-starter :repo "akirak/org-starter"
-             :fetcher github
-             :files
-             ("org-starter.el" "org-starter-*.el"
-              "doc/dir" "doc/*.info" "doc/*.texi" "doc/*.texinfo"
-              (:exclude ".dir-locals.el" "test.el" "tests.el" "*-test.el" "*-tests.el"
-                        "org-starter-swiper.el"
-                        "org-starter-extras.el")))
+(org-starter
+ :repo "akirak/org-starter"
+ :fetcher github
+ :files (:defaults
+         (:exclude "org-starter-swiper.el" "org-starter-extras.el")))



 ~/d/f/melpa   org-starter-update *  make recipes/org-starter              金  7/ 5 22:46:18 2019
 • Building package org-starter ...
Package: org-starter
Fetcher: github
Source:  https://github.com/akirak/org-starter.git

Updating /Users/conao/dev/forks/melpa/working/org-starter/
Copying files (->) and directories (=>)
  from /Users/conao/dev/forks/melpa/working/org-starter/
  to /var/folders/02/ynsv5hcs3cqdn1rff7l5t9680000gn/T/org-starterjqbcOQ/org-starter-20190703.2159
    counsel-org-starter.el -> counsel-org-starter.el
    helm-org-starter.el -> helm-org-starter.el
    org-starter.el -> org-starter.el
Built org-starter in 2.670s, finished at Fri Jul  5 22:46:25 2019
 ✓ Success:
128 -rw-r--r--  1 conao  staff    61K  7  5 22:43 packages/org-starter-20190703.2159.el
  8 -rw-r--r--  1 conao  staff   368B  7  5 22:46 packages/org-starter-20190703.2159.entry
160 -rw-r--r--  1 conao  staff    78K  7  5 22:46 packages/org-starter-20190703.2159.tar
  8 -rw-r--r--  1 conao  staff   969B  7  5 22:46 packages/org-starter-badge.svg
  8 -rw-r--r--  1 conao  staff    68B  7  5 22:46 packages/org-starter-readme.txt
```